### PR TITLE
Remove _score from index meta for bulk processing

### DIFF
--- a/lib/es-export-bulk.js
+++ b/lib/es-export-bulk.js
@@ -152,6 +152,7 @@ var processResults = function (error, response) {
 				source: source
 			});
 		}
+		delete meta.index._score // Remove the score, causes errors in ES 2.3 (maybe earlier versions too)
 		content += JSON.stringify(meta) + '\n' + JSON.stringify(source) + '\n';
 		processed++;
 		bar.tick();


### PR DESCRIPTION
Having _score in the index meta causes Elasticsearch to reject the document in ES 2.3 (and maybe earlier versions too)