### PR TITLE
Updated to v13.1.2 release of elasticsearch-js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _ignore/
 node_modules/
 .DS_Store
+.idea/
 .npm-debug.log
 .project

--- a/lib/es-export-aliases.js
+++ b/lib/es-export-aliases.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('./exporter').indicesExport('getAliases', 'aliases', {
+require('./exporter').indicesExport('getAlias', 'aliases', {
 	index: 'String, String[], Boolean — A comma-separated list of index names',
 	local: 'Boolean — Return local information, do not retrieve the state from master node (default: false)',
 	name: 'String, String[], Boolean — The name of the settings that should be included'

--- a/lib/es-export-bulk.js
+++ b/lib/es-export-bulk.js
@@ -110,9 +110,7 @@ var stdout = program.file == '-';
 
 // build our search object
 var search = {
-	fields: ['*'],
-	_source: true,
-	searchType: 'scan'
+	_source: true
 };
 for (key in esOptions) {
 	if (esOptions.hasOwnProperty(key) && program.hasOwnProperty(key)) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "commander": "^2.9.0",
-    "elasticsearch": "^10.1.2",
+    "elasticsearch": "^13.1.2",
     "filesize": "^3.2.0",
     "line-by-line": "^0.1.4",
     "progress": "^1.1.8"


### PR DESCRIPTION
I've upgraded to the newest release of the official elasticsearch api v13.1.2. With this the "getAliases" method changed to "getAlias". Furthermore I removed the searchType "scan" since the elasticsearch version 5.x no longer supports it and it was deprecated in the past.