### PR TITLE
Fix bulk import socket hang up error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "elasticsearch-tools",
   "version": "4.0.1",
-  "description":
-    "Elasticsearch command line tools for importing, exporting, etc",
+  "description": "Elasticsearch command line tools for importing, exporting, etc",
   "homepage": "http://github.com/skratchdot/elasticsearch-tools",
   "preferGlobal": true,
   "bin": {
@@ -35,7 +34,7 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "elasticsearch": "^14.0.0",
+    "elasticsearch": "^14.2.1",
     "filesize": "^3.2.0",
     "line-by-line": "^0.1.4",
     "prettier": "^1.10.2",


### PR DESCRIPTION
Upgrade elasticsearch dependency to version 14.2.1 to incorporate the timeout fixes for the bulk import. See issue #24 for more details.